### PR TITLE
Fix "embed moved" skip for Markdown link embeds

### DIFF
--- a/e2e/specs/current-note-extraction.spec.ts
+++ b/e2e/specs/current-note-extraction.spec.ts
@@ -75,3 +75,15 @@ test.describe("error handling", () => {
     await expectNoCallout(page);
   });
 });
+
+test("Markdown link embed syntax (issue #51)", async ({ page }) => {
+  await seedNote(
+    page,
+    "Markdown link embed test",
+    "![sample](attachments/sample.pdf)",
+  );
+  await openNote(page, "Markdown link embed test");
+  await extractCurrentNote(page);
+
+  await expectCallout(page, MOCK_OCR_OUTPUT);
+});

--- a/src/text-extractor.ts
+++ b/src/text-extractor.ts
@@ -250,12 +250,7 @@ export class TextExtractor {
   }
 
   private embedMoved(embed: EmbedCache, content: string) {
-    const startOffset = embed.position.start.offset;
-    const endOffset = embed.position.end.offset;
-
-    const startMatches = content.slice(startOffset, startOffset + 3) === "![[";
-    const endMatches = content.slice(endOffset - 2, endOffset) === "]]";
-
-    return !startMatches || !endMatches;
+    const { start, end } = embed.position;
+    return content.slice(start.offset, end.offset) !== embed.original;
   }
 }


### PR DESCRIPTION
Obsidian [embeds](https://obsidian.md/help/embeds) can be created with either [Wikilink or Markdown format links](https://obsidian.md/help/links#Supported+formats+for+internal+links). When adding callouts, the plugin does a safety check to ensure that the embed is in the same position as expected. This check was explicitly using the Wikilink format, so Markdown links (e.g. created by the Evernote importer in some cases) would [result in attachments being skipped](https://github.com/jritzi/ocr-extractor/issues/51) with an "embed moved" warning.

This changes the check to compare the original embed text against the content between the embed start and end positions. This is more robust (since it's checking content and not just link markers) and supports all link types (since it's not checking for specific syntax). A new E2E test was also added to protect against future regressions.