### PR TITLE
Upgrade PDF.js, skip on pdf read errors

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -3,7 +3,7 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
- - pdfjs-dist@5.4.624
+ - pdfjs-dist@6.1.200
 
 This package contains the following license:
 
@@ -1767,36 +1767,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
- - node-readable-to-web-readable-stream@0.4.2
-
-This package contains the following license:
-
-MIT License
-
-Copyright (c) 2025 Borewit
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----------
 

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -130,7 +130,7 @@ export const test = base.extend<ObsidianFixtures>({
     }
   },
 
-  page: async ({ electronApp, allowErrors }, use) => {
+  page: async ({ electronApp, allowErrors }, use, testInfo) => {
     const page = await electronApp.firstWindow();
     let hasConsoleErrors = false;
 
@@ -151,7 +151,13 @@ export const test = base.extend<ObsidianFixtures>({
       .click();
 
     const settingsModal = page.locator(".modal.mod-settings");
-    await settingsModal.locator(".modal-close-button").click();
+    const closeButton = settingsModal.locator(".modal-close-button");
+    if (testInfo.project.name === "old-installer") {
+      // The close button is not visible with this combination of versions
+      await closeButton.dispatchEvent("click");
+    } else {
+      await closeButton.click();
+    }
     await expect(settingsModal).not.toBeVisible();
 
     await injectHttpInterceptor(page);

--- a/e2e-tests/specs/extraction.spec.ts
+++ b/e2e-tests/specs/extraction.spec.ts
@@ -1,6 +1,11 @@
-import { MOCK_OCR_OUTPUT, test } from "../fixtures";
+import { expect, MOCK_OCR_OUTPUT, test } from "../fixtures";
 import { openNote, seedNote } from "../helpers/obsidian";
-import { expectCallout, extractActiveNote } from "../helpers/plugin";
+import {
+  expectCallout,
+  expectNoCallout,
+  extractActiveNote,
+  extractAllNotes,
+} from "../helpers/plugin";
 
 test("Markdown link embed syntax (issue #51)", async ({ page }) => {
   await seedNote(page, "Markdown link embed test", {
@@ -10,4 +15,23 @@ test("Markdown link embed syntax (issue #51)", async ({ page }) => {
   await extractActiveNote(page);
 
   await expectCallout(page, MOCK_OCR_OUTPUT);
+});
+
+test.describe("password-protected PDFs", () => {
+  // Have plugin attempt to open/process PDF
+  test.use({ settings: { preferEmbeddedText: true } });
+
+  test("skipping password-protected PDFs (issue #109)", async ({ page }) => {
+    await seedNote(page, "Note", {
+      content: "![[attachments/password-protected.pdf]]",
+    });
+    await extractAllNotes(page);
+
+    await expect(
+      page.getByText("Text extraction complete. Extracted: 0, skipped: 1"),
+    ).toBeVisible();
+
+    await openNote(page, "Note");
+    await expectNoCallout(page);
+  });
 });

--- a/e2e-tests/test-vault/attachments/password-protected.pdf
+++ b/e2e-tests/test-vault/attachments/password-protected.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 61 >>
+stream
+11Z∑¨¶T;â3Ê©ÃÈÇm5€h@ò¨Bá–†¢ÇÎÀ+¨üÖì7cFi|J l…4ÅY|:PG*@
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Filter /Standard /V 1 /R 2 /O <e5a8d2687bd9d0cff946b7ac55f51081dcf0d116554c4bfcb0a5e446f69ea48a> /U <cec5143d459ab2e6ce5f8014d6978aff66a973637926b3b27415dead0173aa3f> /P -44 >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000352 00000 n 
+0000000422 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R /Encrypt 6 0 R /ID [<4f4352457874726163746f7254657374> <4f4352457874726163746f7254657374>] >>
+startxref
+618
+%%EOF

--- a/e2e-tests/versions.ts
+++ b/e2e-tests/versions.ts
@@ -11,6 +11,7 @@ export const LATEST_VERSION = { name: "latest", obsidian: "1.12.7" };
 
 export const versions: E2EVersions[] = [
   LATEST_VERSION,
-  { name: "old-installer", obsidian: "1.12.7", electron: "34.3.0" },
-  { name: "min-version", obsidian: "1.11.4" },
+  { name: "min-app-version", obsidian: "1.11.4" },
+  { name: "min-electron-version", obsidian: "1.12.7", electron: "37.0.0" },
+  { name: "old-installer", obsidian: "1.12.7", electron: "28.2.3" },
 ];

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -38,6 +38,30 @@ const appendLicenses = {
   },
 };
 
+// PDF.js polyfills Response.prototype.bytes assuming Response exists, but it's
+// undefined on old Electron versions, so it throws at load before the
+// installer update modal can show
+function guardResponsePolyfill(code) {
+  const target = "typeof Response.prototype.bytes";
+  if (!code.includes(target)) {
+    throw new Error("PDF.js Response polyfill not found, update the patch");
+  }
+  return code.replaceAll(
+    target,
+    '(typeof Response === "undefined" ? "function" : typeof Response.prototype.bytes)',
+  );
+}
+
+const patchPdfjsGlobals = {
+  name: "patch-pdfjs-globals",
+  setup(build) {
+    build.onLoad({ filter: /legacy[\\/]build[\\/]pdf\.mjs$/ }, async (args) => {
+      const code = await fs.promises.readFile(args.path, "utf8");
+      return { contents: guardResponsePolyfill(code), loader: "js" };
+    });
+  },
+};
+
 // Plugin to inline the PDF.js worker as a string (to avoid loading from a CDN during runtime)
 const inlinePdfjsWorker = {
   name: "inline-pdfjs-worker",
@@ -45,7 +69,7 @@ const inlinePdfjsWorker = {
     build.onLoad({ filter: /pdf\.worker\.min\.mjs$/ }, async (args) => {
       const code = await fs.promises.readFile(args.path, "utf8");
       return {
-        contents: `export default ${JSON.stringify(code)};`,
+        contents: `export default ${JSON.stringify(guardResponsePolyfill(code))};`,
         loader: "js",
       };
     });
@@ -58,7 +82,11 @@ const context = await esbuild.context({
   },
   entryPoints: ["main.ts"],
   bundle: true,
-  plugins: [inlinePdfjsWorker, ...(prod ? [appendLicenses] : [])],
+  plugins: [
+    patchPdfjsGlobals,
+    inlinePdfjsWorker,
+    ...(prod ? [appendLicenses] : []),
+  ],
   external: [
     "obsidian",
     "electron",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "i18next": "^26.0.6",
     "openai": "^6.42.0",
     "p-limit": "^7.3.0",
-    "pdfjs-dist": "5.4.624",
+    "pdfjs-dist": "6.1.200",
     "semver": "^7.8.0",
     "tesseract.js": "^7.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^7.3.0
         version: 7.3.0
       pdfjs-dist:
-        specifier: 5.4.624
-        version: 5.4.624
+        specifier: 6.1.200
+        version: 6.1.200
       semver:
         specifier: ^7.8.0
         version: 7.8.0
@@ -430,79 +430,79 @@ packages:
     resolution: {integrity: sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==}
     engines: {node: '>=18'}
 
-  '@napi-rs/canvas-android-arm64@0.1.98':
-    resolution: {integrity: sha512-O45Ifr0WZJUrSyg0QgB+67TiC0zYBRkBK+d43ZV4JtlwH3XttiVxLvlxEeULiH5y1MSELruspF0bjF6xXwJNPQ==}
+  '@napi-rs/canvas-android-arm64@1.0.2':
+    resolution: {integrity: sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  '@napi-rs/canvas-darwin-arm64@0.1.98':
-    resolution: {integrity: sha512-1b/nQhw6Isdv14JokUqat+i5wrAYD+ce3egiotedBGRUjVxYSj4s2uQCh2bFsyX5/9A5iTKVGsWoQhFft+j7Lg==}
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@napi-rs/canvas-darwin-x64@0.1.98':
-    resolution: {integrity: sha512-oefzfBM8mwnyYp6S+yNXwjCoLdkOalFG24mssHgvrJDS0FulOryyI35Q7GdJGmrzuL4oo1XW3ZTOcTBLdJ8Zkg==}
+  '@napi-rs/canvas-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.98':
-    resolution: {integrity: sha512-NDH5QXGmf8wlo5yhijCNGVFiJk7an5GvHwb2LHyfLQWY/6/S48i5+YtY6FPqPVVCUckNGudYOfXEJnb3/FiJGQ==}
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.98':
-    resolution: {integrity: sha512-KBLLM6tu1xs80LSAqdSLBKkgct0S23MCEf/aq8yxzg5imAceqp1ulKeELgWaYm27MgpUhm3Q7jmegX12FfphwA==}
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.98':
-    resolution: {integrity: sha512-mfMNhjN5zDcJafqQ6sHj4Tc3YMTRxP5UA3MHtp/ssytBR/k6XO0x+1IIPtscnUKwha+ql1++WjDCGEgqu8OfWQ==}
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.98':
-    resolution: {integrity: sha512-nfW8esrcaeuhrO3qGA5cwuyk4Ak6cn2eB0LtEYtqROIl+fz06CNGNCU0M95+Tspw5ZgfSbc98SaigT5r5B3LVQ==}
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
+    resolution: {integrity: sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.98':
-    resolution: {integrity: sha512-318UT8j6Gro2bTjtutjQXHWp9SLTNw+WRS4wQ6XIRPAyzBGnGHg7x2ndD+oqkPrrSRIbYLA5WoBcCasaF7lSTQ==}
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.98':
-    resolution: {integrity: sha512-0vZhI74UxnA4VqlW4UvM0dFRrjE1RLEe/OXSBjzytGIxV+yOG4exlrhGoIpAQaIpQQQXMCdb1EmbvPC1k9vEqQ==}
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.98':
-    resolution: {integrity: sha512-oiC/IxgFEEVcZ7VH7JXXlmgsqRvmFb57PIQ4gQck35IKFZCNUvdNCcN3OeoLP7Hpf5160MWJf9jj/+E5V0bSvw==}
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.98':
-    resolution: {integrity: sha512-ZqstKAJBSyZetU8udUvBQWPlGN9buawFvjuo9mgCAxzbOoJAgXX39ihec/nn42T5Vb6/qyn45eTimx5ND9kMEw==}
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/canvas@0.1.98':
-    resolution: {integrity: sha512-WDg3lxYMqlrg49sDVUlrHVfIEPsd5AjYDRuGD6Fu82K5agJx0UnWA+l5qd53GNLRiMN2WhOw7FLR+Er5QB/0SA==}
+  '@napi-rs/canvas@1.0.2':
+    resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
     engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.5':
@@ -2002,9 +2002,6 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
-  node-readable-to-web-readable-stream@0.4.2:
-    resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
-
   nopt@9.0.0:
     resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2164,9 +2161,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pdfjs-dist@5.4.624:
-    resolution: {integrity: sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==}
-    engines: {node: '>=20.16.0 || >=22.3.0'}
+  pdfjs-dist@6.1.200:
+    resolution: {integrity: sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==}
+    engines: {node: '>=22.13.0 || >=24'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3076,52 +3073,52 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/canvas-android-arm64@0.1.98':
+  '@napi-rs/canvas-android-arm64@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-darwin-arm64@0.1.98':
+  '@napi-rs/canvas-darwin-arm64@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-darwin-x64@0.1.98':
+  '@napi-rs/canvas-darwin-x64@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.98':
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.98':
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-linux-arm64-musl@0.1.98':
+  '@napi-rs/canvas-linux-arm64-musl@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.98':
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-gnu@0.1.98':
+  '@napi-rs/canvas-linux-x64-gnu@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-linux-x64-musl@0.1.98':
+  '@napi-rs/canvas-linux-x64-musl@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.98':
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.2':
     optional: true
 
-  '@napi-rs/canvas-win32-x64-msvc@0.1.98':
+  '@napi-rs/canvas-win32-x64-msvc@1.0.2':
     optional: true
 
-  '@napi-rs/canvas@0.1.98':
+  '@napi-rs/canvas@1.0.2':
     optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.98
-      '@napi-rs/canvas-darwin-arm64': 0.1.98
-      '@napi-rs/canvas-darwin-x64': 0.1.98
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.98
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.98
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.98
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.98
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.98
-      '@napi-rs/canvas-linux-x64-musl': 0.1.98
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.98
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.98
+      '@napi-rs/canvas-android-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-arm64': 1.0.2
+      '@napi-rs/canvas-darwin-x64': 1.0.2
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.2
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.2
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.2
+      '@napi-rs/canvas-linux-x64-musl': 1.0.2
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.2
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -4915,9 +4912,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  node-readable-to-web-readable-stream@0.4.2:
-    optional: true
-
   nopt@9.0.0:
     dependencies:
       abbrev: 4.0.0
@@ -5121,10 +5115,9 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pdfjs-dist@5.4.624:
+  pdfjs-dist@6.1.200:
     optionalDependencies:
-      '@napi-rs/canvas': 0.1.98
-      node-readable-to-web-readable-stream: 0.4.2
+      '@napi-rs/canvas': 1.0.2
 
   picocolors@1.1.1: {}
 

--- a/src/engines/ocr-engine.ts
+++ b/src/engines/ocr-engine.ts
@@ -2,7 +2,7 @@ import { fileTypeFromBuffer } from "file-type";
 import type { SecretStorage } from "obsidian";
 import { PluginSettings } from "../settings";
 import { warnSkipped } from "../utils/logging";
-import { getPdfTextContent, isPdf } from "../utils/pdf";
+import { getPdfTextContent, isPdf, PdfReadError } from "../utils/pdf";
 import { raceAbort } from "../utils/async";
 import { OcrEngineSettingsClass } from "./ocr-engine-settings";
 
@@ -45,26 +45,34 @@ export abstract class OcrEngine {
       return null;
     }
 
-    if (isPdf(mimeType) && this.settings.preferEmbeddedText) {
-      const pages = await raceAbort(getPdfTextContent(data), signal);
-      if (pages === null) return null;
-      const result = this.joinPages(pages);
-      if (result) return result;
-    }
+    try {
+      if (isPdf(mimeType) && this.settings.preferEmbeddedText) {
+        const pages = await raceAbort(getPdfTextContent(data), signal);
+        if (pages === null) return null;
+        const result = this.joinPages(pages);
+        if (result) return result;
+      }
 
-    const pages = await raceAbort(
-      this.extractPages(data, mimeType, filename, signal),
-      signal,
-    );
-    if (pages === null) {
-      return null;
+      const pages = await raceAbort(
+        this.extractPages(data, mimeType, filename, signal),
+        signal,
+      );
+      if (pages === null) {
+        return null;
+      }
+      const result = this.joinPages(pages);
+      if (!result) {
+        warnSkipped(filename, "no text to extract");
+        return "";
+      }
+      return result;
+    } catch (error) {
+      if (error instanceof PdfReadError) {
+        warnSkipped(filename, error.message);
+        return null;
+      }
+      throw error;
     }
-    const result = this.joinPages(pages);
-    if (!result) {
-      warnSkipped(filename, "no text to extract");
-      return "";
-    }
-    return result;
   }
 
   /** Clean up any resources held by this engine. */

--- a/src/min-electron-version.ts
+++ b/src/min-electron-version.ts
@@ -1,10 +1,6 @@
 import { coerce, lt, valid } from "semver";
 
-// pdfjs-dist >=4.8.69 calls Uint8Array.prototype.toHex() unconditionally, which
-// requires Chrome 140+ / Electron 38.0.0+
-// https://github.com/mozilla/pdf.js/discussions/20770
-// https://github.com/jritzi/ocr-extractor/issues/57
-export const MIN_ELECTRON_VERSION = "38.0.0";
+export const MIN_ELECTRON_VERSION = "37.0.0";
 
 export function isElectronBelowMinimum(currentVersion: string) {
   const current = valid(coerce(currentVersion));

--- a/src/pdfjs-worker.d.ts
+++ b/src/pdfjs-worker.d.ts
@@ -1,4 +1,0 @@
-declare module "pdfjs-dist/build/pdf.worker.min.mjs" {
-  const workerCode: string;
-  export default workerCode;
-}

--- a/src/pdfjs.d.ts
+++ b/src/pdfjs.d.ts
@@ -1,0 +1,8 @@
+declare module "pdfjs-dist/legacy/build/pdf.mjs" {
+  export * from "pdfjs-dist";
+}
+
+declare module "pdfjs-dist/legacy/build/pdf.worker.min.mjs" {
+  const workerCode: string;
+  export default workerCode;
+}

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -1,12 +1,19 @@
-import type { PDFPageProxy } from "pdfjs-dist";
-import { getDocument, GlobalWorkerOptions } from "pdfjs-dist";
+// Use legacy build to support older Chrome/Electron versions
+import {
+  getDocument,
+  GlobalWorkerOptions,
+  PasswordException,
+  type PDFPageProxy,
+} from "pdfjs-dist/legacy/build/pdf.mjs";
 import type { TextItem } from "pdfjs-dist/types/src/display/api";
-import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.mjs";
+import pdfjsWorker from "pdfjs-dist/legacy/build/pdf.worker.min.mjs";
 import { canvasToPng } from "./image";
 
 GlobalWorkerOptions.workerSrc = URL.createObjectURL(
   new Blob([pdfjsWorker], { type: "application/javascript" }),
 );
+
+export class PdfReadError extends Error {}
 
 export function isPdf(mimeType: string) {
   return mimeType === "application/pdf";
@@ -52,34 +59,47 @@ export async function convertPdfToImages(
   });
 }
 
+/**
+ * Runs `callback` on each page and returns the collected results. Any error
+ * thrown here skips the PDF with a PdfReadError.
+ */
 async function mapPdfPages<T>(
   data: Uint8Array,
   callback: (page: PDFPageProxy) => Promise<T>,
 ) {
-  const pdf = await getDocument({
-    // Copy data before passing to pdfjs (it detaches the original, preventing
-    // the caller from using `data` later)
-    data: new Uint8Array(data),
-    useWorkerFetch: false,
-    isEvalSupported: false,
-    disableAutoFetch: true,
-  }).promise;
-
   try {
-    const results: T[] = [];
+    const loadingTask = getDocument({
+      // Copy data before passing to pdfjs (it detaches the original, preventing
+      // the caller from using `data` later)
+      data: new Uint8Array(data),
+      useWorkerFetch: false,
+      disableAutoFetch: true,
+    });
 
-    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
-      const pdfPage = await pdf.getPage(pageNum);
+    try {
+      const pdf = await loadingTask.promise;
+      const results: T[] = [];
 
-      try {
-        results.push(await callback(pdfPage));
-      } finally {
-        pdfPage.cleanup();
+      for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+        const pdfPage = await pdf.getPage(pageNum);
+
+        try {
+          results.push(await callback(pdfPage));
+        } finally {
+          pdfPage.cleanup();
+        }
       }
-    }
 
-    return results;
-  } finally {
-    await pdf.destroy();
+      return results;
+    } finally {
+      await loadingTask.destroy();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const reason =
+      error instanceof PasswordException
+        ? "password-protected PDF"
+        : `could not process PDF (${message})`;
+    throw new PdfReadError(reason, { cause: error });
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jritzi/ocr-extractor/issues/109 by upgrading PDF.js to fix "Invalid page request" errors (https://github.com/mozilla/pdf.js/issues/20629) and treating unexpected PDF read errors as a skip instead of a fatal error. Also switched from the modern to the legacy PDF.js build for better version support.